### PR TITLE
Fix CATAAS Integration with updated API structure

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -10,7 +10,7 @@ function About() {
 
     try {
       const response = await axios.get('https://cataas.com/cat?json=true');
-      const imageUrl = `https://cataas.com${response.data.url}`;
+      const imageUrl = `https://cataas.com/cat/${response.data._id}`;
       setCatImage(imageUrl);
     } catch (error) {
       console.error('Error fetching cat image:', error);


### PR DESCRIPTION
Fixed so a cat actually shows up properly in about page and we have a successful example of linking with an API :) I think they must have changed the API in the past year or so because now they no longer give you the direct image url, just an id so you have to construct it yourself... really trivial change though.

<img width="1369" alt="Screen Shot 2024-02-04 at 2 51 42 PM" src="https://github.com/dali-lab/23s-frontend-miniseries-react-demo/assets/40366749/89cf57b1-c9a2-42da-ad48-9043c19275c2">
